### PR TITLE
Added a dict-like items() function and fixed __iter__() for dicts

### DIFF
--- a/traversify/traverser.py
+++ b/traversify/traverser.py
@@ -131,6 +131,11 @@ class Traverser(object):
             return
         wrapped_value = wrap_value(current_value)
         wrapped_value[part] = buildout_path(parts[index+1:], new_value)
+        
+    def items(self):
+        if type(self()) == list:
+            return [wrap_value(x) for x in self()]
+        return [(key, wrap_value(subtree)) for key, subtree in self().items()]
 
     def ensure_list(self, item):
         value = self.get(item)
@@ -216,7 +221,7 @@ class Traverser(object):
                 result.append(wrap_value(value))
             return iter(result)
         else:
-            return iter([self])
+            return iter([wrap_value(x) for x in self().values()])
 
     def __add__(self, item):
         value = ensure_list(self())


### PR DESCRIPTION
The list iterator gives back iterators to traversers of subtrees in that list. In case of a dict, it would be nice to get back traverses of subtrees for dictionaries as well, my change in __iter__() fixes just that.

I also added a function items(). Similar to this function for a dict, it gives back a list of subtrees for a list, and tuples like this (dict_key, subtree_for_key). As far as I have tested these two additions work like a charm. In order to run my program I needed both, and now it's really awesome to use traversify! 

If you think these changes are ok, I'd be glad if you could merge them into a newer version :)